### PR TITLE
Update Edition Seed and Remove /editions route.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,7 +11,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    [ :first_name, :last_name, :username, :sex, :is_univ_student, :is_student_at_minho_univ,
+    [	:first_name, :last_name, :username, :sex, :is_univ_student, :is_student_at_minho_univ,
       :is_inf_eng_student_at_minho_univ, :is_cesium_associate,
       :cesium_associate_number, :minho_univ_student_id, :university,
       :course, :location, :profession
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
       devise_parameter_sanitizer.permit(:sign_up, keys: [p])
     end
 
-    [ :birthday, :biography, :facebook_account, :twitter_account,
+    [	:birthday, :biography, :facebook_account, :twitter_account,
       :github_account, :google_plus_account, :avatar, :cesium_associate_number
     ].each do |p|
       devise_parameter_sanitizer.permit(:account_update, keys: [p])
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_global_info
-    @edition = Edition.find(2016)
+    @edition = Edition.find(2017)
     @activities = @edition.activities
   end
 end

--- a/app/views/layouts/_navbar.slim
+++ b/app/views/layouts/_navbar.slim
@@ -14,16 +14,16 @@ nav#navbar.navbar.navbar-default.navbar-fixed-top
       ul.nav.navbar-nav.navbar-right
         li class=(is_participants_active?)
           = link_to "Participantes",
-            edition_participants_path(edition_id: 2016)
+            edition_participants_path(edition_id: @edition.id)
         li class=(is_badges_active?)
           = link_to "Badges",
-            edition_badges_path(edition_id: 2016)
+            edition_badges_path(edition_id: @edition.id)
         li class=(is_redeem_badge_active?)
           = link_to "Requisitar Badge",
-            redeem_edition_badges_path(edition_id: 2016)
+            redeem_edition_badges_path(edition_id: @edition.id)
         li class=(is_profile_active?)
           = link_to "Perfil",
-            edition_participant_path(username: current_user.username, edition_id: 2016)
+            edition_participant_path(username: current_user.username, edition_id: @edition.id)
         li
           = link_to "Logout", destroy_user_session_path, method: :delete
     /! /.navbar-collapse

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 	get 'intranet' => 'intranet#intranet'
 	get 'intranet' => 'intranet#intranet', as: 'user_root'
 
-	resources :editions, only: [:show] do
+	resources :editions, only: [] do
 
 		resources :participants, only: [:index, :show], param: :username
 		get 'hall_of_fame' => 'participants#hall_of_fame'

--- a/db/seeds_files/editions.rb
+++ b/db/seeds_files/editions.rb
@@ -2,12 +2,12 @@ module Seed
 	def self.editions
 		Edition.create!([
 			{
-				id: 2016,
-				name: "II Semana de Engenharia Informática na Universidade do Minho",
-				edition_number: 2,
-				description: '',
-				begin_date: DateTime.civil_from_format(:local, 2016, 2, 6),
-				end_date: DateTime.civil_from_format(:local, 2016, 2, 13)
+				id: 2017,
+				name: "III Semana de Engenharia Informática na Universidade do Minho",
+				edition_number: 3,
+				description: '3ª Edição da Semana da Engenharia Informática da Universidade do Minho',
+				begin_date: DateTime.civil_from_format(:local, 2017, 2, 4),
+				end_date: DateTime.civil_from_format(:local, 2017, 2, 11)
 			}
 		])
 	end


### PR DESCRIPTION
- Update Edition Seed to the 2017 edition. The application controller was also updated to provide the 2017 edition as `@edition` and navbar urls have also been updated due to this.
- Remove /editions GET path because we are not currently concerned with supporting multiple editions.