### PR TITLE
Update seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,18 +2,3 @@ Dir[File.dirname(__FILE__) + "/seeds_files/*"].each { |file| require_relative fi
 
 # Editions
 editions = Seed::editions
-
-# Companies
-companies = Seed::companies(editions)
-
-# Speakers
-speakers = Seed::speakers(editions, companies)
-
-# Activities
-# activities = Seed::activities(editions, speakers)
-activities = []
-
-Seed::users
-
-# Badges
-badges = RakeBadgeCreation::badges


### PR DESCRIPTION
- Leave only Editions on the seeds files.
- The other seeds were not being used, except RakeBadgeCreation.
- Remove RakeBadgeCreation seed because it is no longer working as a
consequence of switching to S3.