### PR TITLE
Preserve file in S3

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -76,10 +76,11 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-	Paperclip.options[:command_path] = "/usr/bin/"
+  Paperclip.options[:command_path] = "/usr/bin/"
   config.paperclip_defaults = {
     storage: :s3,
     s3_credentials: {
+      preserve_files: true,
       bucket: ENV.fetch("S3_BUCKET_NAME"),
       access_key_id: ENV.fetch("AWS_ACCESS_KEY_ID"),
       secret_access_key: ENV.fetch("AWS_SECRET_ACCESS_KEY"),


### PR DESCRIPTION
As per the [wiki](https://github.com/thoughtbot/paperclip/wiki/Paperclip-with-Amazon-S3), this is needed to avoid file loss.