### PR TITLE
Get usernames with more than 10 badges and multiply them by the number of badges

### DIFF
--- a/lib/tasks/get_winners.rake
+++ b/lib/tasks/get_winners.rake
@@ -1,0 +1,7 @@
+namespace :sei do
+  desc "give an array of usernames times the number of badges of the users with atleast 10 badges"
+
+  task :get_winners => :environment do |t, args|
+      puts User.all.select{|b| b.badges.count >= 10 and !b.is_organizer}
+        .map{|u| Array.new(u.badges.count,u.username)}.flatten.shuffle
+end


### PR DESCRIPTION
I multiplied the number of usernames because on the website say's that the more badges u have the most likely you are of winning.
There's also an option to return them already shuffled @9thScientist your call :)